### PR TITLE
Fix assignment syntax error in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Dictionary for all of the inherited `QUEEN_objects` used to construct the presen
   **Source code**
   ```python
   from queen import *
-  fragment **=** QUEEN(seq**=**"CCGGTATGCG----/----ATACGCAGCT") 
+  fragment = QUEEN(seq="CCGGTATGCG----/----ATACGCAGCT") 
   fragment.printsequence(display=True)
   ```
   


### PR DESCRIPTION
The README indicates to use `**=**` as both a variable and parameter assignment, which is not valid Python. Fixed to use `=`.